### PR TITLE
Fix download URL of netcoredb

### DIFF
--- a/scripts/download-netcoredbg.js
+++ b/scripts/download-netcoredbg.js
@@ -21,7 +21,7 @@ const mkdirp = require('mkdirp');
 
 // @ts-ignore
 const packagePath = path.join(__dirname, '..');
-let downloadUrl = 'https://github.com/Samsung/netcoredbg/releases/download/latest/netcoredbg-linux-master.tar.gz';
+let downloadUrl = 'https://github.com/Samsung/netcoredbg/releases/download/1.2.0-635/netcoredbg-linux-focal.tar.gz';
 const downloadDir = 'debug';
 const filename = 'netcoredbg-linux-master.tar.gz';
 const downloadPath = path.join(packagePath, downloadDir);
@@ -55,7 +55,7 @@ function downloadNetCoreDBG() {
                     response.pipe(file);
                 } else {
                     file.destroy();
-                    reject(new Error(`Failed to download omnisharp-roslyn with code: ${statusCode}`));
+                    reject(new Error(`Failed to download netcoredbg with code: ${statusCode}`));
                 }
             })
 


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>
Since download URL for netcoredbg was changed (https://github.com/Samsung/netcoredbg/releases) we have to fix it in the plugin.